### PR TITLE
force noninteractive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu AS qemu-system-arm-builder
 ARG QEMU_VERSION=4.2.0
 ENV QEMU_TARBALL="qemu-${QEMU_VERSION}.tar.xz"
+ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /qemu
 
 RUN apt-get update && \
@@ -48,7 +49,7 @@ ADD $RPI_KERNEL_URL /tmp/qemu-rpi-kernel.zip
 
 RUN apt-get update && \
     apt-get -y install \
-			unzip \ 
+			unzip \
 			expect
 RUN cd /tmp && \
     echo "$RPI_KERNEL_CHECKSUM  qemu-rpi-kernel.zip" | sha256sum -c && \


### PR DESCRIPTION
On ubuntu I got stuck in:
```
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

 1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
 2. America     5. Arctic     8. Europe    11. SystemV
 3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 
```
Add env var for dpkg to avoid interactive mode.